### PR TITLE
Add 'restart: always' to compose containers

### DIFF
--- a/geowebservice/docker-compose.yml
+++ b/geowebservice/docker-compose.yml
@@ -3,12 +3,14 @@ version: "3"
 services:
   solr:
     image: solr:8.11
+    restart: always
     volumes:
       - geodata:/opt/solr/server/solr
 
   geodropdownservice:
     build:
       context: .
+    restart: always
     ports:
       - "8886:8000"
     depends_on:


### PR DESCRIPTION
This PR adds `restart: always` to both containers, so that these can automatically be restarted in the event of failures, server shutdown, etc.